### PR TITLE
Update GHA workflows

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,9 +9,4 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - uses: actions/setup-node@v3
-        with:
-          node-version: 'lts/*'
-          cache: 'npm'
-          cache-dependency-path: '**/.github/workflows/*.yml'
       - run: npx awesome-lint


### PR DESCRIPTION
setup-node wasn't caching the npx package, so remove it

Signed-off-by: James Taylor <jamest@uk.ibm.com>